### PR TITLE
Send metrics as floats

### DIFF
--- a/src/Statsd.cpp
+++ b/src/Statsd.cpp
@@ -57,7 +57,7 @@ inline bool Statsd::shouldSend(float sample_rate) {
     return random(100) < (sample_rate * 100);
 }
 
-void Statsd::send(String metric, int value, String tags, String type, float sample_rate) {
+void Statsd::send(String metric, float value, String tags, String type, float sample_rate) {
     if(!shouldSend(sample_rate))
         return;
     String msg;
@@ -89,54 +89,54 @@ void Statsd::event(String title, String text) {
 }
 
 // Count
-void Statsd::count(String metric, int value, String tags, float sample_rate) {
+void Statsd::count(String metric, float value, String tags, float sample_rate) {
     send(metric, value, tags, "c", sample_rate);
 }
 
-void Statsd::count(String metric, int value) {
+void Statsd::count(String metric, float value) {
     send(metric, value, "", "c", 1.0);
 }
 
-void Statsd::count(String metric, int value, float sample_rate) {
+void Statsd::count(String metric, float value, float sample_rate) {
     send(metric, value, "", "c", sample_rate);
 }
 
 // Gauge
-void Statsd::gauge(String metric, int value, String tags, float sample_rate) {
+void Statsd::gauge(String metric, float value, String tags, float sample_rate) {
     send(metric, value, tags, "g", sample_rate);
 }
 
-void Statsd::gauge(String metric, int value) {
+void Statsd::gauge(String metric, float value) {
     send(metric, value, "", "g", 1.0);
 }
 
-void Statsd::gauge(String metric, int value, float sample_rate) {
+void Statsd::gauge(String metric, float value, float sample_rate) {
     send(metric, value, "", "g", sample_rate);
 }
 
 // Set
-void Statsd::set(String metric, int value, String tags, float sample_rate) {
+void Statsd::set(String metric, float value, String tags, float sample_rate) {
     send(metric, value, tags, "s", sample_rate);
 }
 
-void Statsd::set(String metric, int value) {
+void Statsd::set(String metric, float value) {
     send(metric, value, "", "s", 1.0);
 }
 
-void Statsd::set(String metric, int value, float sample_rate) {
+void Statsd::set(String metric, float value, float sample_rate) {
     send(metric, value, "", "s", sample_rate);
 }
 
 // Timing
-void Statsd::timing(String metric, int value, String tags, float sample_rate) {
+void Statsd::timing(String metric, float value, String tags, float sample_rate) {
     send(metric, value, tags, "ms", sample_rate);
 }
 
-void Statsd::timing(String metric, int value) {
+void Statsd::timing(String metric, float value) {
     send(metric, value, "", "ms", 1.0);
 }
 
-void Statsd::timing(String metric, int value, float sample_rate) {
+void Statsd::timing(String metric, float value, float sample_rate) {
     send(metric, value, "", "ms", sample_rate);
 }
 

--- a/src/Statsd.h
+++ b/src/Statsd.h
@@ -19,21 +19,21 @@ public:
     void event(String title, String text, String tags);
     void event(String title, String text);
     // Count
-    void count(String metric, int value, String tags, float sample_rate);
-    void count(String metric, int value);
-    void count(String metric, int value, float sample_rate);
+    void count(String metric, float value, String tags, float sample_rate);
+    void count(String metric, float value);
+    void count(String metric, float value, float sample_rate);
     // Gauge
-    void gauge(String metric, int value, String tags, float sample_rate);
-    void gauge(String metric, int value);
-    void gauge(String metric, int value, float sample_rate);
+    void gauge(String metric, float value, String tags, float sample_rate);
+    void gauge(String metric, float value);
+    void gauge(String metric, float value, float sample_rate);
     // Set
-    void set(String metric, int value, String tags, float sample_rate);
-    void set(String metric, int value);
-    void set(String metric, int value, float sample_rate);
+    void set(String metric, float value, String tags, float sample_rate);
+    void set(String metric, float value);
+    void set(String metric, float value, float sample_rate);
     // Timing
-    void timing(String metric, int value, String tags, float sample_rate);
-    void timing(String metric, int value);
-    void timing(String metric, int value, float sample_rate);
+    void timing(String metric, float value, String tags, float sample_rate);
+    void timing(String metric, float value);
+    void timing(String metric, float value, float sample_rate);
     // Increment
     void increment(String metric, String tags, float sample_rate);
     void increment(String metric);
@@ -47,7 +47,7 @@ private:
     String formatTags(String constant_tags, String tags);
     String formatSampleRate(float sample_rate);
     bool shouldSend(float sample_rate);
-    void send(String metric, int value, String tags, String type, float sample_rate);
+    void send(String metric, float value, String tags, String type, float sample_rate);
     UDP &_udp;
     String _host;
     uint16_t _port;


### PR DESCRIPTION
Hi, thanks for you work on the library, it's very useful and I've be using it to report some metrics from NodeMCUs

I noticed some floats value are cast to int (and truncated) because of the signature of the functions. I've updated them to be floats 
